### PR TITLE
Introduce database caching and command line commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.5 - 2021-11-13
+### Fixed
+- Fixed bug that occurred on Craft CMS installations with table prefixes. Thank you @gbowne-quickbase! #1
+
 ## 1.0.4 - 2021-10-25
 ### Added
 - Added support for SEOmatic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.6 - 2021-11-18
+### Added
+- Added support for Users.
+
+### Fixed
+- Fixed bug that occurred on prefixed SEOmatic fields.
+- SEOmatic and Profile Photo check now only occur when element is an Asset. -> Performance
+
 ## 1.0.5 - 2021-11-13
 ### Fixed
 - Fixed bug that occurred on Craft CMS installations with table prefixes. Thank you @gbowne-quickbase! #1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 1.0.6 - 2021-11-18
 ### Added
-- Added support for Users.
+- Added support for Profile Photos.
 
 ### Fixed
 - Fixed bug that occurred on prefixed SEOmatic fields.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ As a basis the relations table is used. This means that any field that stores re
 * NEO
 * SuperTable
 * SEOmatic
+* Profile Photos
 * ... and many more.
 
 **Not supported:**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "internetztube/craft-element-relations",
     "description": "Shows all relations of an element.",
     "type": "craft-plugin",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "internetztube/craft-element-relations",
     "description": "Shows all relations of an element.",
     "type": "craft-plugin",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/ElementRelationsService.php
+++ b/src/services/ElementRelationsService.php
@@ -79,10 +79,14 @@ class ElementRelationsService extends Component
             ->map(function($row) { return (int) $row; })->unique()
             ->contains($sourceElement->id);
 
-        $fields = (new Query)->select(['handle'])
+        $fields = (new Query)->select(['handle', 'columnSuffix'])
             ->from(Table::FIELDS)
             ->where(['=', 'type', 'nystudio107\seomatic\fields\SeoSettings'])
-            ->column();
+            ->all();
+        $fields = collect($fields)->map(function ($field) {
+            if (empty($field['columnSuffix'])) { return $field['handle']; }
+            return sprintf('%s_%s', $field['handle'], $field['columnSuffix']);
+        })->toArray();
 
         $foundElements = collect();
 

--- a/src/services/ElementRelationsService.php
+++ b/src/services/ElementRelationsService.php
@@ -76,8 +76,8 @@ class ElementRelationsService extends Component
         collect($fields)->each(function ($handle) use (&$foundElements, $extractIdFromString, $sourceElement) {
             $fieldHandle = sprintf('field_%s', $handle);
             $rows = (new Query)->select(['elements.canonicalId', 'elements.id', 'siteId', 'title', 'content.'.$fieldHandle])
-                ->from(Table::CONTENT)
-                ->innerJoin(Table::ELEMENTS, '[[elements.id]] = [[content.elementId]]')
+                ->from(['content' => Table::CONTENT])
+                ->innerJoin(['elements' => Table::ELEMENTS], '[[elements.id]] = [[content.elementId]]')
                 ->where(['NOT', ['content.'.$fieldHandle => null]])
                 ->all();
             collect($rows)->each(function ($row) use (&$foundElements, $extractIdFromString, $fieldHandle, $sourceElement) {

--- a/src/services/ElementRelationsService.php
+++ b/src/services/ElementRelationsService.php
@@ -37,7 +37,20 @@ class ElementRelationsService extends Component
         return $result['type']::find()->id($elementId)->anyStatus()->site($site)->one();
     }
 
-    public static function isUsedInSEOmatic(Element $sourceElement)
+    public static function assetUsageInProfilePhotos(Element $sourceElement)
+    {
+        $users = (new Query())
+            ->select(['id'])
+            ->from(Table::USERS)
+            ->where(['photoId' => $sourceElement->id])
+            ->all();
+
+        return collect($users)->map(function (array $user) {
+            return \Craft::$app->users->getUserById($user['id']);
+        })->all();
+    }
+
+    public static function assetUsageInSEOmatic(Element $sourceElement)
     {
         $result = ['usedGlobally' => false, 'elements' => []];
         $isInstalled = \Craft::$app->db->tableExists('{{%seomatic_metabundles}}');


### PR DESCRIPTION
Creates table on install or upgrade.
Adds command line/console commands to build or refresh the cache
Builds config/settings model to allow users to define cache duration
Dramatically speeds up the process for sites with lots of assets and content

Should fix #3